### PR TITLE
Suppport pure java lib

### DIFF
--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -374,8 +374,7 @@ task embedJavaJars(dependsOn: generateXClass) << {
  */
 task embedJniLibs << {
     println "Running FAT-AAR Task :embedJniLibs"
-
-        println "======= Copying JNI from $aarPath/jni"
+    
     libraryPaths.each { jarPath ->
         // Copy JNI Folders
         println "======= Copying JNI from $jarPath/jni"

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -68,7 +68,9 @@ dependencies {
     compile configurations.embedded
 }
 
+// Paths containing *.jar
 ext.libraryPaths = new ArrayList<String>()
+// Paths containing *.aar (this may contain several paths already added to the libraryPaths array).
 ext.embeddedAarDirs = new ArrayList<String>()
 ext.build_dir = "build";
 
@@ -83,16 +85,11 @@ ext.post_r2x_dir = "build/fat-aar/release/post-r2x";
 ext.fat_aar_pro_file = "fataar-rules.pro";
 
 afterEvaluate {
-    // the list of dependency must be reversed to use the right overlay order.
-    def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
-    dependencies.reverseEach {
-        def aarPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
-        if (!embeddedAarDirs.contains(aarPath)) {
-            embeddedAarDirs.add(aarPath)
-        }
-    }
 
-    dependencies.each {
+    def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
+
+    // The list of dependency must be reversed to use the right overlay order.
+    dependencies.reverseEach {
         collectDependencies(it)
     }
 
@@ -135,18 +132,27 @@ afterEvaluate {
 }
 
 public void collectDependencies(ResolvedDependency it) {
+    println "Running FAT-AAR method: collectDependencies "
     it.moduleArtifacts.each {
         artifact ->
+            def artifactPath;
             if (artifact.type == 'aar') {
-                def aarPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
-                if (!embeddedAarDirs.contains(aarPath) && !libraryPaths.contains(aarPath))
-                    libraryPaths.add(aarPath)
+                artifactPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
+
+                if (!embeddedAarDirs.contains(artifactPath)) {
+//                    println "Add aar path: ${artifactPath}";
+                    embeddedAarDirs.add(artifactPath)
+        }
+
             } else if (artifact.type == 'jar') {
-                def artifactPath = artifact.file
-                if (!libraryPaths.contains(artifactPath))
-                    libraryPaths.add(artifactPath)
+                artifactPath = artifact.file
             } else {
                 throw new Exception("Unhandled Artifact of type ${artifact.type}")
+            }
+
+            if (!libraryPaths.contains(artifactPath)) {
+//                println "Add jar path: ${artifactPath} and type: ${artifact.type}";
+                libraryPaths.add(artifactPath)
             }
     }
 
@@ -207,9 +213,9 @@ task embedProguard << {
     println "Running FAT-AAR Task :embedProguard"
 
     def proguardRelease = file("$bundle_release_dir/proguard.txt")
-    embeddedAarDirs.each { aarPath ->
+    libraryPaths.each { jarPath ->
         try {
-            def proguardLibFile = file("$aarPath/proguard.txt")
+            def proguardLibFile = file("$jarPath/proguard.txt")
             if (proguardLibFile.exists())
                 proguardRelease.append(proguardLibFile.text)
         } catch (Exception e) {
@@ -227,19 +233,19 @@ task copyJavaJars << {
     file(base_r2x_dir).deleteDir()
     mkdir(base_r2x_dir)
 
-    embeddedAarDirs.each { aarPath ->
+    libraryPaths.each { jarPath ->
         // Collect list of all jar files
-        FileTree jars = fileTree(dir: "$aarPath/jars", include: ['*.jar'])
-        jars += fileTree(dir: "$aarPath/jars/libs", include: ['*.jar']);
-        jars += fileTree(dir: "$aarPath", include: ['*.jar']);
-        jars += fileTree(dir: "$aarPath/libs", include: ['*.jar']);
-
-        // println "Embedding jars : " + jars
+        FileTree jars = fileTree(dir: "$jarPath/jars", include: ['*.jar'])
+        jars += fileTree(dir: "$jarPath/jars/libs", include: ['*.jar']);
+        jars += fileTree(dir: "$jarPath", include: ['*.jar']);
+        jars += fileTree(dir: "$jarPath/libs", include: ['*.jar']);
 
         // Explode all jar files to classes so that they can be proguarded
         jars.visit {
             FileVisitDetails element ->
                 copy {
+                    println "    Copy jar from : ${element.file}";
+
                     from(zipTree(element.file))
                     into(pree_r2x_dir)
                 }
@@ -254,7 +260,6 @@ task generateRJava(dependsOn: copyJavaJars) << {
     def libPackageName = new XmlParser().parse(android.sourceSets.main.manifest.srcFile).@package
     def mappingRText = "# Mapping file to convert R.class to X.class" << '\n' << '\n';
     embeddedAarDirs.each { aarPath ->
-
         def aarManifest = new XmlParser().parse(file("$aarPath/AndroidManifest.xml"));
         def aarPackageName = aarManifest.@package
         String packagePath = aarPackageName.replace('.', '/')
@@ -358,8 +363,14 @@ task embedJavaJars(dependsOn: generateXClass) << {
     println "Running FAT-AAR Task :embedJavaJars"
 
     copy {
+
+        println "===================================";
+        println "from : $post_r2x_dir";
+        println "to : $classs_release_dir";
+
         from fileTree(dir: post_r2x_dir)
         into file(classs_release_dir)
+        println "===================================";
     }
 }
 
@@ -369,11 +380,11 @@ task embedJavaJars(dependsOn: generateXClass) << {
 task embedJniLibs << {
     println "Running FAT-AAR Task :embedJniLibs"
 
-    embeddedAarDirs.each { aarPath ->
-        println "======= Copying JNI from $aarPath/jni"
+    libraryPaths.each { jarPath ->
         // Copy JNI Folders
+        println "======= Copying JNI from $jarPath/jni"
         copy {
-            from fileTree(dir: "$aarPath/jni")
+            from fileTree(dir: "$jarPath/jni")
             into file("$bundle_release_dir/jni")
         }
     }
@@ -386,9 +397,9 @@ task embedManifests << {
     List<File> libraryManifests = new ArrayList<>()
 
     embeddedAarDirs.each { aarPath ->
-        if (!libraryManifests.contains(aarPath)) {
+        if (!libraryManifests.contains(aarPath))
+        {
             libraryManifests.add(file("$aarPath/AndroidManifest.xml"))
-            // println "==== Added $aarPath Manifest"
         }
     }
 

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -260,6 +260,7 @@ task generateRJava(dependsOn: copyJavaJars) << {
     def libPackageName = new XmlParser().parse(android.sourceSets.main.manifest.srcFile).@package
     def mappingRText = "# Mapping file to convert R.class to X.class" << '\n' << '\n';
     embeddedAarDirs.each { aarPath ->
+
         def aarManifest = new XmlParser().parse(file("$aarPath/AndroidManifest.xml"));
         def aarPackageName = aarManifest.@package
         String packagePath = aarPackageName.replace('.', '/')
@@ -363,14 +364,8 @@ task embedJavaJars(dependsOn: generateXClass) << {
     println "Running FAT-AAR Task :embedJavaJars"
 
     copy {
-
-        println "===================================";
-        println "from : $post_r2x_dir";
-        println "to : $classs_release_dir";
-
         from fileTree(dir: post_r2x_dir)
         into file(classs_release_dir)
-        println "===================================";
     }
 }
 
@@ -380,6 +375,7 @@ task embedJavaJars(dependsOn: generateXClass) << {
 task embedJniLibs << {
     println "Running FAT-AAR Task :embedJniLibs"
 
+        println "======= Copying JNI from $aarPath/jni"
     libraryPaths.each { jarPath ->
         // Copy JNI Folders
         println "======= Copying JNI from $jarPath/jni"
@@ -397,9 +393,9 @@ task embedManifests << {
     List<File> libraryManifests = new ArrayList<>()
 
     embeddedAarDirs.each { aarPath ->
-        if (!libraryManifests.contains(aarPath))
-        {
+        if (!libraryManifests.contains(aarPath)) {
             libraryManifests.add(file("$aarPath/AndroidManifest.xml"))
+            // println "==== Added $aarPath Manifest"
         }
     }
 


### PR DESCRIPTION
Hello,

This is a fix for embedding pure java library projects.

I've separated the concerns of "jar" libraries from "aar" libraries within the script. 

The aar libraries contains resources, assets, manifest files. These items don't exist within a java library, which causes some issues.

The initial issue was that embedded jar libraries are getting added to the embeddedAarDir array. This had two consequences:
- The embeddedAarDir was used to find the libraries *.jar file. The aar libraries are added to the "build/intermediates/exploded-aar" directory, whereas pure java libraries remain in their own build directory.  This meant that the pure java libraries were never being found.
- There was a loop around embeddedAarDir for merging the AndroidManifest.xml files. However, because the pure java libraries don't have manifest files, this was causing an failure in the script.