### PR TITLE
Fix for multiple proguard options in same line

### DIFF
--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -156,7 +156,6 @@ task embedAssets << {
 
 /**
  * Merge proguard.txt files from all library modules
- * @author Marian Klühspies
  */
 task embedProguard << {
     println "====== Embedding proguard.txt files in " + project
@@ -165,7 +164,7 @@ task embedProguard << {
         try {
             def proguardLibFile = file("$aarPath/proguard.txt")
             if (proguardLibFile.exists())
-                proguardRelease.append(proguardLibFile.text)
+                proguardRelease.append("\n" + proguardLibFile.text)
         } catch (Exception e) {
             e.printStackTrace();
             throw e;


### PR DESCRIPTION
This fix adds a new line feed to the append process to merge proguard files in a new line