### PR TITLE
Fixed issue #46

### DIFF
--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -116,7 +116,7 @@ afterEvaluate {
 
         // Embed JNI Libraries
         bundleRelease.dependsOn embedJniLibs
-        embedJniLibs.dependsOn transformNative_libsWithSyncJniLibsForRelease
+        embedJniLibs.dependsOn transformNativeLibsWithSyncJniLibsForRelease
 
         // Merge Embedded Manifests
         bundleRelease.dependsOn embedManifests


### PR DESCRIPTION
The Android build tools have changed a task name:
transformNative_libsWithSyncJniLibsForRelease -> transformNativeLibsWithSyncJniLibsForRelease