### PR TITLE
Fix Gradle 3.3 + compiled path that contains /builds/ path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # android-fat-aar
-Gradle script that allows you to merge and embed dependencies in generted aar file. 
+Gradle script that allows you to merge and embed dependencies in generated aar file. 
+
+In this Fork you can find a fixed version who will also work with embedded .aar files !
 
 **Credits**
 

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -22,7 +22,7 @@
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
 
- For more information, please refer to <http://unlicense.org/>
+ For more information, please refer to
  */
 
 
@@ -54,7 +54,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:manifest-merger:25.2.0'
+        classpath 'com.android.tools.build:manifest-merger:25.3.2'
     }
 }
 
@@ -67,32 +67,63 @@ dependencies {
 }
 
 // Paths to embedded jar files
-ext.embeddedJars = new ArrayList<String>()
+ext.embeddedJars = new ArrayList()
 // Paths to embedded aar projects
-ext.embeddedAarDirs = new ArrayList<String>()
+ext.embeddedAarDirs = new ArrayList()
 // List of embedded R classes
-ext.embeddedRClasses = new ArrayList<String>()
+ext.embeddedRClasses = new ArrayList()
 
 // Change backslash to forward slash on windows
 ext.build_dir = buildDir.path.replace(File.separator, '/');
-
+ext.root_dir = project.rootDir.absolutePath.replace(File.separator, '/');
 ext.exploded_aar_dir = "$build_dir/intermediates/exploded-aar";
 ext.classs_release_dir = "$build_dir/intermediates/classes/release";
-ext.bundle_release_dir = "$build_dir/intermediates/bundles/release";
 ext.manifest_aaapt_dir = "$build_dir/intermediates/manifests/aapt/release";
 ext.generated_rsrc_dir = "$build_dir/generated/source/r/release";
 
 ext.base_r2x_dir = "$build_dir/fat-aar/release/";
 
+def apiVersionString
+project.rootProject.buildscript.configurations.classpath.each {
+    if (it.name.contains("gradle-api"))
+        apiVersionString = it.name
+}
+apiVersionString = apiVersionString.replace('gradle-api-', '').replace('.jar', '');
+ext.gradleApiVersion = apiVersionString.substring(0, apiVersionString.lastIndexOf('.')).toFloat()
+
+if (gradleApiVersion >= 2.3f) {
+    ext.taskTransformNativeLib = "transformNativeLibsWithSyncJniLibsForRelease"
+    ext.bundle_release_dir = "$build_dir/intermediates/bundles/default";
+}
+else {
+    ext.taskTransformNativeLib = "transformNative_libsWithSyncJniLibsForRelease"
+    ext.bundle_release_dir = "$build_dir/intermediates/bundles/release";
+}
+
+
 afterEvaluate {
     // the list of dependency must be reversed to use the right overlay order.
     def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
     dependencies.reverseEach {
-        def aarPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
+        def aarPath;
+        if (gradleApiVersion >= 2.3f)
+            aarPath = "${root_dir}/${it.moduleName}/build/intermediates/bundles/default"
+        else
+            aarPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
         it.moduleArtifacts.each {
             artifact ->
+
                 if (artifact.type == 'aar') {
                     if (!embeddedAarDirs.contains(aarPath)) {
+                        if( !artifact.file.isDirectory() ){
+                            println artifact.file
+                            println aarPath
+
+                            copy {
+                                from zipTree( artifact.file )
+                                into aarPath
+                            }
+                        }
                         embeddedAarDirs.add(aarPath)
                     }
                 } else if (artifact.type == 'jar') {
@@ -116,7 +147,7 @@ afterEvaluate {
 
         // Embed JNI Libraries
         bundleRelease.dependsOn embedJniLibs
-        embedJniLibs.dependsOn transformNative_libsWithSyncJniLibsForRelease
+        embedJniLibs.dependsOn "$taskTransformNativeLib"
 
         // Merge Embedded Manifests
         bundleRelease.dependsOn embedManifests
@@ -161,10 +192,20 @@ private List getMergedInputResourceSets(List inputResourceSet) {
 
     embeddedAarDirs.each { aarPath ->
         try {
-            def resname = (aarPath.split(exploded_aar_dir)[1]).replace('/', ':');
+            def resname
+            if (gradleApiVersion >= 2.3f) {
+                def parentProject = project.rootProject.name.toString()
+                def startIndex = aarPath.indexOf('/' + parentProject)
+                def endIndex = aarPath.indexOf('/build')
+                if (startIndex < 1 || endIndex < 1)
+                    return;
+                resname = aarPath.substring(startIndex, endIndex).replace('/', ':')
+            }
+            else
+                resname = (aarPath.split(exploded_aar_dir)[1]).replace('/', ':');
             def rs = ResourceSetClass.newInstance([resname, true] as Object[])
             rs.addSource(file("$aarPath/res"))
-            // println "ResourceSet is " + rs
+//            println "ResourceSet is " + rs
             newInputResourceSet += rs
         } catch (Exception e) {
             e.printStackTrace();
@@ -281,14 +322,19 @@ task embedJavaJars(dependsOn: embedRClass) << {
 
     embeddedAarDirs.each { aarPath ->
         // Explode all classes.jar files to classes so that they can be proguarded
+        def jar_dir
+        if (gradleApiVersion >= 2.3f)
+            jar_dir = "$aarPath"
+        else
+            jar_dir = "$aarPath/jars"
         copy {
-            from zipTree("$aarPath/jars/classes.jar")
+            from zipTree(jar_dir + "/classes.jar")
             into classs_release_dir
         }
 
         // Copy all additional jar files to bundle lib
-        FileTree jars = fileTree(dir: "$aarPath/jars", include: '*.jar', exclude: 'classes.jar')
-        jars += fileTree(dir: "$aarPath/jars/libs", include: '*.jar')
+        FileTree jars = fileTree(dir: jar_dir, include: '*.jar', exclude: 'classes.jar')
+        jars += fileTree(dir: jar_dir + "/libs", include: '*.jar')
         jars += fileTree(dir: "$aarPath/libs", include: '*.jar')
 
         copy {
@@ -324,7 +370,7 @@ task embedManifests << {
     println "Running FAT-AAR Task :embedManifests"
 
     ILogger mLogger = new MiLogger()
-    List<File> libraryManifests = new ArrayList<>()
+    List libraryManifests = new ArrayList<>()
 
     embeddedAarDirs.each { aarPath ->
         if (!libraryManifests.contains(aarPath)) {

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -327,6 +327,12 @@ task embedJavaJars(dependsOn: embedRClass) << {
             jar_dir = "$aarPath"
         else
             jar_dir = "$aarPath/jars"
+
+        println jar_dir
+        println classs_release_dir
+        println bundle_release_dir
+        println embeddedJars
+
         copy {
             from zipTree(jar_dir + "/classes.jar")
             into classs_release_dir

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -205,8 +205,16 @@ private List getMergedInputResourceSets(List inputResourceSet) {
             def resname
             if (gradleApiVersion >= 2.3f) {
                 def parentProject = project.rootProject.name.toString()
+                println "parent: "
+                println parentProject
+
                 def startIndex = aarPath.indexOf('/' + parentProject)
                 def endIndex = aarPath.indexOf('/build')
+
+                println "start"
+                println startIndex
+                println "end"
+                println endIndex
                 if (startIndex < 1 || endIndex < 1)
                     return;
                 resname = aarPath.substring(startIndex, endIndex).replace('/', ':')

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -103,6 +103,8 @@ else {
 
 afterEvaluate {
 
+    println "GRADLE API 1 "
+    println gradleApiVersion
     // the list of dependency must be reversed to use the right overlay order.
     def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
     dependencies.reverseEach {
@@ -115,9 +117,9 @@ afterEvaluate {
         it.moduleArtifacts.each {
             artifact ->
 
-                println "GRADLE API "
+                println "GRADLE API 2 "
                 println gradleApiVersion
-                println "ARTIFACT 2 : "
+                println "ARTIFACT 3 : "
                 println artifact
                 if (artifact.type == 'aar') {
                     if (!embeddedAarDirs.contains(aarPath)) {

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -211,7 +211,8 @@ private List getMergedInputResourceSets(List inputResourceSet) {
                 resname = (aarPath.split(exploded_aar_dir)[1]).replace('/', ':');
             def rs = ResourceSetClass.newInstance([resname, true] as Object[])
             rs.addSource(file("$aarPath/res"))
-//            println "ResourceSet is " + rs
+            println "ResourceSet is " + rs
+            println resname
             newInputResourceSet += rs
         } catch (Exception e) {
             e.printStackTrace();
@@ -315,7 +316,6 @@ task collectRClass << {
     }
 }
 
-//TODO on dirait qu'il passe pas là
 task embedRClass(type: org.gradle.jvm.tasks.Jar, dependsOn: collectRClass) {
     println "EMBED R CLASS"
 

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -113,6 +113,8 @@ afterEvaluate {
         it.moduleArtifacts.each {
             artifact ->
 
+                println "ARTIFACT : "
+                println artifact
                 if (artifact.type == 'aar') {
                     if (!embeddedAarDirs.contains(aarPath)) {
                         if( !artifact.file.isDirectory() ){

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -311,8 +311,12 @@ task collectRClass << {
 
 //TODO on dirait qu'il passe pas là
 task embedRClass(type: org.gradle.jvm.tasks.Jar, dependsOn: collectRClass) {
+    println "EMBED R CLASS"
+
     destinationDir file("$bundle_release_dir/libs/")
+    println destinationDir
     from base_r2x_dir
+    println base_r2x_dir
 }
 
 /**

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -102,11 +102,12 @@ else {
 
 
 afterEvaluate {
+    println "GRADLE API "
+    println gradleApiVersion
+
     // the list of dependency must be reversed to use the right overlay order.
     def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
     dependencies.reverseEach {
-        println "GRADLE API "
-        println gradleApiVersion
 
         def aarPath;
         if (gradleApiVersion >= 2.3f)

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -102,8 +102,6 @@ else {
 
 
 afterEvaluate {
-    println "GRADLE API "
-    println gradleApiVersion
 
     // the list of dependency must be reversed to use the right overlay order.
     def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
@@ -117,6 +115,8 @@ afterEvaluate {
         it.moduleArtifacts.each {
             artifact ->
 
+                println "GRADLE API "
+                println gradleApiVersion
                 println "ARTIFACT : "
                 println artifact
                 if (artifact.type == 'aar') {

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -298,6 +298,7 @@ task generateRJava << {
 }
 
 task collectRClass << {
+    println "COLLECTRCLASS"
     delete base_r2x_dir
     mkdir base_r2x_dir
 
@@ -308,6 +309,7 @@ task collectRClass << {
     }
 }
 
+//TODO on dirait qu'il passe pas là
 task embedRClass(type: org.gradle.jvm.tasks.Jar, dependsOn: collectRClass) {
     destinationDir file("$bundle_release_dir/libs/")
     from base_r2x_dir

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -105,6 +105,9 @@ afterEvaluate {
     // the list of dependency must be reversed to use the right overlay order.
     def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
     dependencies.reverseEach {
+        println "GRADLE API "
+        println gradleApiVersion
+
         def aarPath;
         if (gradleApiVersion >= 2.3f)
             aarPath = "${root_dir}/${it.moduleName}/build/intermediates/bundles/default"

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -209,7 +209,7 @@ private List getMergedInputResourceSets(List inputResourceSet) {
                 println parentProject
 
                 def startIndex = aarPath.indexOf('/' + parentProject)
-                def endIndex = aarPath.indexOf('/build')
+                def endIndex = aarPath.indexOf('/build/')
 
                 println "start"
                 println startIndex

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -196,8 +196,12 @@ private List getMergedInputResourceSets(List inputResourceSet) {
 
     List newInputResourceSet = new ArrayList(inputResourceSet)
 
+    println "getMergedInputResourceSets"
+
+    println embeddedAarDirs
     embeddedAarDirs.each { aarPath ->
         try {
+            println aarPath
             def resname
             if (gradleApiVersion >= 2.3f) {
                 def parentProject = project.rootProject.name.toString()

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -117,7 +117,7 @@ afterEvaluate {
 
                 println "GRADLE API "
                 println gradleApiVersion
-                println "ARTIFACT : "
+                println "ARTIFACT 2 : "
                 println artifact
                 if (artifact.type == 'aar') {
                     if (!embeddedAarDirs.contains(aarPath)) {

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -117,8 +117,6 @@ afterEvaluate {
         it.moduleArtifacts.each {
             artifact ->
 
-                println "GRADLE API 2 "
-                println gradleApiVersion
                 println "ARTIFACT 3 : "
                 println artifact
                 if (artifact.type == 'aar') {


### PR DESCRIPTION
This fix some errors:
- Fix Gradle updates compatibility
- When the compiled destination contains /builds/ directory that is not inside the compiled files, compiled aar missed some resources
