### PR TITLE
[Fat aar] Android .aar module dependency support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.3.3'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+
 apply plugin: 'com.android.library'
 
 // For publishing
@@ -6,7 +19,7 @@ version '1.2.3'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 16
@@ -29,8 +42,8 @@ dependencies {
 
     // Order of dependencies decide which will have precedence in case of duplicates
     // during manifest / resource merger
-    embedded project(':librarytwo')
-    embedded project(':libraryone')
+//    embedded project(':librarytwo')
+//    embedded project(':libraryone')
     // We can embed android libraries from maven too
     embedded 'com.adwiv.internal:librarythree:1.0.0'
 

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -80,11 +80,16 @@ ext.build_dir = buildDir.path.replace(File.separator, '/');
 ext.root_dir = project.rootDir.absolutePath.replace(File.separator, '/');
 ext.exploded_aar_dir = "$build_dir/intermediates/exploded-aar";
 ext.classs_release_dir = "$build_dir/intermediates/classes/release";
+ext.bundle_release_dir = "$build_dir/intermediates/bundles/release";
 ext.manifest_aaapt_dir = "$build_dir/intermediates/manifests/aapt/release";
 ext.generated_rsrc_dir = "$build_dir/generated/source/r/release";
 
 ext.base_r2x_dir = "$build_dir/fat-aar/release/";
-ext.gradleApiVersion = GradleVersion.current().getVersion().toFloat();
+
+def gradleVersionStr = GradleVersion.current().getVersion();
+ext.gradleApiVersion = gradleVersionStr.substring(0, gradleVersionStr.lastIndexOf(".")).toFloat();
+
+println "Gradle version: " + gradleVersionStr;
 
 afterEvaluate {
     // the list of dependency must be reversed to use the right overlay order.
@@ -264,7 +269,13 @@ task generateRJava << {
     println "Running FAT-AAR Task :generateRJava"
 
     // Now generate the R.java file for each embedded dependency
-    def libPackageName = new XmlParser().parse(android.sourceSets.main.manifest.srcFile).@package
+    def mainManifestFile = android.sourceSets.main.manifest.srcFile;
+    def libPackageName = "";
+
+    if(mainManifestFile.exists()) {
+
+        libPackageName = new XmlParser().parse(mainManifestFile).@package
+    }
 
     embeddedAarDirs.each { aarPath ->
 
@@ -272,45 +283,49 @@ task generateRJava << {
         if(!manifestFile.exists()) {
             manifestFile = file("./src/main/AndroidManifest.xml");
         }
-        def aarManifest = new XmlParser().parse(manifestFile);
-        def aarPackageName = aarManifest.@package
 
-        String packagePath = aarPackageName.replace('.', '/')
+        if(manifestFile.exists()) {
+            def aarManifest = new XmlParser().parse(manifestFile);
+            def aarPackageName = aarManifest.@package
 
-        // Generate the R.java file and map to current project's R.java
-        // This will recreate the class file
-        def rTxt = file("$aarPath/R.txt")
-        def rMap = new ConfigObject()
+            String packagePath = aarPackageName.replace('.', '/')
 
-        if (rTxt.exists()) {
-            rTxt.eachLine {
-                line ->
-                    //noinspection GroovyUnusedAssignment
-                    def (type, subclass, name, value) = line.tokenize(' ')
-                    rMap[subclass].putAt(name, type)
-            }
-        }
+            // Generate the R.java file and map to current project's R.java
+            // This will recreate the class file
+            def rTxt = file("$aarPath/R.txt")
+            def rMap = new ConfigObject()
 
-        def sb = "package $aarPackageName;" << '\n' << '\n'
-        sb << 'public final class R {' << '\n'
-
-        rMap.each {
-            subclass, values ->
-                sb << "  public static final class $subclass {" << '\n'
-                values.each {
-                    name, type ->
-                        sb << "    public static $type $name = ${libPackageName}.R.${subclass}.${name};" << '\n'
+            if (rTxt.exists()) {
+                rTxt.eachLine {
+                    line ->
+                        //noinspection GroovyUnusedAssignment
+                        def (type, subclass, name, value) = line.tokenize(' ')
+                        rMap[subclass].putAt(name, type)
                 }
-                sb << "    }" << '\n'
+            }
+
+            def sb = "package $aarPackageName;" << '\n' << '\n'
+            sb << 'public final class R {' << '\n'
+
+            rMap.each {
+                subclass, values ->
+                    sb << "  public static final class $subclass {" << '\n'
+                    values.each {
+                        name, type ->
+                            sb << "    public static $type $name = ${libPackageName}.R.${subclass}.${name};" << '\n'
+                    }
+                    sb << "    }" << '\n'
+            }
+
+            sb << '}' << '\n'
+
+            mkdir("$generated_rsrc_dir/$packagePath")
+            file("$generated_rsrc_dir/$packagePath/R.java").write(sb.toString())
+
+            embeddedRClasses += "$packagePath/R.class"
+            embeddedRClasses += "$packagePath/R\$*.class"
         }
 
-        sb << '}' << '\n'
-
-        mkdir("$generated_rsrc_dir/$packagePath")
-        file("$generated_rsrc_dir/$packagePath/R.java").write(sb.toString())
-
-        embeddedRClasses += "$packagePath/R.class"
-        embeddedRClasses += "$packagePath/R\$*.class"
     }
 }
 
@@ -344,6 +359,13 @@ task embedJavaJars(dependsOn: embedRClass) << {
 
     embeddedAarDirs.each { aarPath ->
 
+        // Explode all classes.jar files to classes so that they can be proguarded
+        def jar_dir
+        if (gradleApiVersion >= 2.3f)
+            jar_dir = "$aarPath"
+        else
+            jar_dir = "$aarPath/jars"
+
         if(embeddedAarFiles.size() > 0){
 
             embeddedAarFiles.each {
@@ -359,13 +381,6 @@ task embedJavaJars(dependsOn: embedRClass) << {
             }
 
         }else{
-
-            // Explode all classes.jar files to classes so that they can be proguarded
-		    def jar_dir
-		    if (gradleApiVersion >= 2.3f)
-		        jar_dir = "$aarPath"
-		    else
-		        jar_dir = "$aarPath/jars"
 
 		    println jar_dir
 		    println classs_release_dir
@@ -434,6 +449,10 @@ task embedManifests << {
 
     if(!origManifest.exists()) {
         origManifest = file("./src/main/AndroidManifest.xml")
+    }
+
+    if(!origManifest.exists()) {
+        return;
     }
 
     copy {

--- a/fat-aar.gradle
+++ b/fat-aar.gradle
@@ -70,6 +70,8 @@ dependencies {
 ext.embeddedJars = new ArrayList<String>()
 // Paths to embedded aar projects
 ext.embeddedAarDirs = new ArrayList<String>()
+// Embedded aar files dependencies
+ext.embeddedAarFiles = new ArrayList<ResolvedArtifact>()
 // List of embedded R classes
 ext.embeddedRClasses = new ArrayList<String>()
 
@@ -91,7 +93,11 @@ afterEvaluate {
         def aarPath = "${exploded_aar_dir}/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
         it.moduleArtifacts.each {
             artifact ->
+
                 if (artifact.type == 'aar') {
+                    if (!embeddedAarFiles.contains(artifact)) {
+                        embeddedAarFiles.add(artifact)
+                    }
                     if (!embeddedAarDirs.contains(aarPath)) {
                         embeddedAarDirs.add(aarPath)
                     }
@@ -116,7 +122,15 @@ afterEvaluate {
 
         // Embed JNI Libraries
         bundleRelease.dependsOn embedJniLibs
-        embedJniLibs.dependsOn transformNative_libsWithSyncJniLibsForRelease
+
+        if(GradleVersion.current().getVersion().toFloat() >= 2.3f) {
+
+            embedJniLibs.dependsOn transformNativeLibsWithSyncJniLibsForRelease
+            ext.bundle_release_dir = "$build_dir/intermediates/bundles/default"
+        }else{
+            embedJniLibs.dependsOn transformNative_libsWithSyncJniLibsForRelease
+            ext.bundle_release_dir = "$build_dir/intermediates/bundles/release";
+        }
 
         // Merge Embedded Manifests
         bundleRelease.dependsOn embedManifests
@@ -215,8 +229,13 @@ task generateRJava << {
 
     embeddedAarDirs.each { aarPath ->
 
-        def aarManifest = new XmlParser().parse(file("$aarPath/AndroidManifest.xml"));
+        def manifestFile = file("$aarPath/AndroidManifest.xml");
+        if(!manifestFile.exists()) {
+            manifestFile = file("./src/main/AndroidManifest.xml");
+        }
+        def aarManifest = new XmlParser().parse(manifestFile);
         def aarPackageName = aarManifest.@package
+
         String packagePath = aarPackageName.replace('.', '/')
 
         // Generate the R.java file and map to current project's R.java
@@ -280,10 +299,30 @@ task embedJavaJars(dependsOn: embedRClass) << {
     println "Running FAT-AAR Task :embedJavaJars"
 
     embeddedAarDirs.each { aarPath ->
-        // Explode all classes.jar files to classes so that they can be proguarded
-        copy {
-            from zipTree("$aarPath/jars/classes.jar")
-            into classs_release_dir
+
+//        aarFile = configurations.runtime.files;
+        if(embeddedAarFiles.size() > 0){
+
+            embeddedAarFiles.each {
+                artifact ->
+                    FileTree aarFileTree = zipTree(artifact.file.getAbsolutePath());
+
+                    def aarFile = aarFileTree.files.find { it.name.contains("classes.jar") }
+
+                    copy {
+                        from zipTree(aarFile)
+                        into classs_release_dir
+                    }
+            }
+
+        }else{
+
+            // Explode all classes.jar files to classes so that they can be proguarded
+            copy {
+
+                from zipTree("$aarPath/jars/classes.jar")
+                into classs_release_dir
+            }
         }
 
         // Copy all additional jar files to bundle lib
@@ -327,8 +366,10 @@ task embedManifests << {
     List<File> libraryManifests = new ArrayList<>()
 
     embeddedAarDirs.each { aarPath ->
-        if (!libraryManifests.contains(aarPath)) {
-            libraryManifests.add(file("$aarPath/AndroidManifest.xml"))
+        File dependencyManifest = file("$aarPath/AndroidManifest.xml")
+
+        if (!libraryManifests.contains(aarPath) && dependencyManifest.exists()) {
+            libraryManifests.add(dependencyManifest)
         }
     }
 
@@ -337,6 +378,10 @@ task embedManifests << {
     File origManifest = file("$bundle_release_dir/AndroidManifest.xml")
     File copyManifest = file("$bundle_release_dir/AndroidManifest.orig.xml")
     File aaptManifest = file("$manifest_aaapt_dir/AndroidManifest.xml")
+
+    if(!origManifest.exists()) {
+        origManifest = file("./src/main/AndroidManifest.xml")
+    }
 
     copy {
         from origManifest.parentFile


### PR DESCRIPTION
Using the `fat-aar.gradle` tasks to generate a `.aar` from a module/project that declare others modules that have a `.aar` file defined like a `artifact`, throws erros in many of tasks.

This PR enable support for this situtation. The changes below were did:

* Added `AndroidManifest.xml` verifications (module dependencies that contains only a  `.aar` not contains this file).
* Extract `classes.jar` from the `.aar` in this module dependencies.
* Added `gradle` version verification to avoid `transformNative_libsWithSyncJniLibsForRelease` task not found error, related on issue #64 